### PR TITLE
Expose timeout.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,9 @@ pip-log.txt
 
 # Mac crap
 .DS_Store
+
+
+#############
+## Emacs
+#############
+*~

--- a/hipchat/__init__.py
+++ b/hipchat/__init__.py
@@ -26,7 +26,7 @@ class HipChat(object):
                 return self.method
             return urllib2.Request.get_method(self)
 
-    def method(self, url, method="GET", parameters=None):
+    def method(self, url, method="GET", parameters=None, timeout=None):
         method_url = urljoin(self.url, url)
 
         if method == "GET":
@@ -52,7 +52,7 @@ class HipChat(object):
         method_url = method_url + '?' + query_string
 
         req = self.RequestWithMethod(method_url, http_method=method, data=request_data)
-        response = self.opener.open(req).read()
+        response = self.opener.open(req, None, timeout).read()
 
         return json.loads(response)
 


### PR DESCRIPTION
Expose `timeout` on `hipchat.method` so that it's safer to use synchronously on a path that shouldn't hang. Leaves current signature/behavior unchanged -- it would probably be a good idea to default the timeout to something reasonable, though.

(This is actually a pretty bad interface, but doesn't break existing code and it gets the job done.  Ideally you'd specify the timeout once, or make it easier to override the opener, or something, I guess.)
